### PR TITLE
Fix fs-helper exists

### DIFF
--- a/lib/fs-helpers.js
+++ b/lib/fs-helpers.js
@@ -20,7 +20,7 @@ function exists(filename) {
                 return err.code === 'ENOENT' ? resolve(false) : reject(err);
             }
 
-            return true;
+            return resolve(true);
         });
     });
 }


### PR DESCRIPTION
Helper `write` doesn't work for existing dirs, because `exists` returns `boolean`.

```
function write(filename, content) {
    var dirname = path.dirname(filename);

    return exists(dirname).then(function(doesExists) {
        ...
```
