### PR TITLE
Add postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/bem-site/bem-lib-site-view.git"
   },
   "scripts": {
-    "prepublish": "enb make",
+    "prepublish": "bower install && enb make",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Vladimir Grinenko <i@tadatuta.com>",


### PR DESCRIPTION
``` bash
git clone git@github.com:bem-site/bem-lib-site-view.git
cd bem-lib-site-view
npm install
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global jison@0.4.13 should be installed with -g

> jsonpath@0.2.7 postinstall /space/projects/gendocs/test/bem-lib-site-view/node_modules/jsonpath
> node lib/aesprim.js > generated/aesprim-browser.js


> bem-lib-site-view@0.0.5 prepublish /space/projects/gendocs/test/bem-lib-site-view
> enb make

13:23:44.585 - build started
13:23:44.626 - [rebuild] [desktop.bundles/index/index.bemdecl.js] file-provider
13:23:44.630 - [failed] [desktop.bundles/index/index.levels] levels
13:23:44.630 - [failed] [desktop.bundles/index/index.deps.js] deps
13:23:44.630 - [failed] [desktop.bundles/index/index.files] files
13:23:44.630 - [failed] [desktop.bundles/index/index.bemhtml.deps.js] deps
13:23:44.630 - [failed] [desktop.bundles/index/index.bemhtml.files] files
13:23:44.630 - [failed] [desktop.bundles/index/index.bemhtml.bemdecl.js] deps-by-tech-to-bemdecl
13:23:44.631 - [failed] [desktop.bundles/index/index.bemtree.js] bemtree
13:23:44.631 - [failed] [desktop.bundles/index/index.bemhtml.js] bemhtml
13:23:44.631 - [failed] [desktop.bundles/index/index.css] stylus
13:23:44.631 - [failed] [desktop.bundles/index/index.browser.js] browser-js
13:23:44.631 - [failed] [desktop.bundles/index/index.browser.bemhtml.js] bemhtml
13:23:44.632 - [failed] [desktop.bundles/index/index.js] file-merge
13:23:44.632 - build failed
Error: ENOENT: no such file or directory, scandir '/space/projects/gendocs/test/bem-lib-site-view/libs/bem-core/common.blocks'
    at Error (native)
    at Object.fs.readdirSync (fs.js:856:18)
    at module.exports.inherit.load (/space/projects/gendocs/test/bem-lib-site-view/node_modules/enb-bem-techs/lib/levels/level.js:212:28)
    at /space/projects/gendocs/test/bem-lib-site-view/node_modules/enb-bem-techs/techs/levels.js:112:38
    at Array.map (native)
    at /space/projects/gendocs/test/bem-lib-site-view/node_modules/enb-bem-techs/techs/levels.js:111:42
    at Array.<anonymous> (/space/projects/gendocs/test/bem-lib-site-view/node_modules/vow/lib/vow.js:712:56)
    at Immediate.callFns [as _onImmediate] (/space/projects/gendocs/test/bem-lib-site-view/node_modules/vow/lib/vow.js:23:35)
    at processImmediate [as _immediateCallback] (timers.js:383:17)

npm ERR! Linux 4.2.0-42-generic
npm ERR! argv "/home/ilyar/.nvm/versions/node/v5.5.0/bin/node" "/home/ilyar/.nvm/versions/node/v5.5.0/bin/npm" "i"
npm ERR! node v5.5.0
npm ERR! npm  v3.8.1
npm ERR! code ELIFECYCLE
npm ERR! bem-lib-site-view@0.0.5 prepublish: `enb make`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the bem-lib-site-view@0.0.5 prepublish script 'enb make'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the bem-lib-site-view package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     enb make
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs bem-lib-site-view
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls bem-lib-site-view
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /space/projects/gendocs/test/bem-lib-site-view/npm-debug.log
```
